### PR TITLE
docs: drop flake-utils from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,28 @@ To use this overlay, add it to your `flake.nix` inputs:
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     fdb-overlay.url = "github:foundationdb-rs/overlay";
   };
 
-  outputs = { self, nixpkgs, flake-utils, fdb-overlay, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ fdb-overlay.overlays.default ];
-        };
-      in
-      {
-        devShells.default = pkgs.mkShell {
-          packages = [ pkgs.libfdb pkgs.fdbcli ];
-        };
-      }
-    );
+  outputs =
+    {
+      nixpkgs,
+      fdb-overlay,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ fdb-overlay.overlays.default ];
+      };
+    in
+    {
+      devShells."${system}".default = pkgs.mkShell {
+        packages = with pkgs; [ libfdb fdbcli ];
+      };
+    };
 }
 ```
 

--- a/examples/override/flake.nix
+++ b/examples/override/flake.nix
@@ -1,8 +1,8 @@
 {
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixos-unstable;
-    flake-utils.url = github:numtide/flake-utils;
-    fdb-overlay.url = path:./../..;
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fdb-overlay.url = "path:./../..";
   };
 
   outputs = { nixpkgs, flake-utils, fdb-overlay, ... }:

--- a/examples/override/flake.nix
+++ b/examples/override/flake.nix
@@ -1,28 +1,34 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     fdb-overlay.url = "path:./../..";
   };
 
-  outputs = { nixpkgs, flake-utils, fdb-overlay, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
-      system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ fdb-overlay.overlays.default ];
-        };
-        libfdb7149 = pkgs.libfdb71.overrideAttrs (finalAttrs: previousAttrs: {
+  outputs =
+    {
+      nixpkgs,
+      fdb-overlay,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ fdb-overlay.overlays.default ];
+      };
+
+      libfdb7149 = pkgs.libfdb71.overrideAttrs (
+        finalAttrs: previousAttrs: {
           version = "7.1.49";
           sha256 = "7464326281f8d3d6bad2e4fe85f494e84cd54a842fbed237c1fcbe3f1387f9d1";
-        });
-      in
-      {
-        devShell = pkgs.mkShell {
-          nativeBuildInputs = [ libfdb7149 ];
-          FDB_LIB_PATH = "${libfdb7149}/include";
-        };
-      }
-    );
+        }
+      );
+    in
+    {
+      devShells."${system}".default = pkgs.mkShell {
+        nativeBuildInputs = [ libfdb7149 ];
+        FDB_LIB_PATH = "${libfdb7149}/include";
+      };
+    };
 }

--- a/examples/simple-71/flake.nix
+++ b/examples/simple-71/flake.nix
@@ -1,8 +1,8 @@
 {
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixos-unstable;
-    flake-utils.url = github:numtide/flake-utils;
-    fdb-overlay.url = path:./../..;
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fdb-overlay.url = "path:./../..";
   };
 
   outputs = { nixpkgs, flake-utils, fdb-overlay, ... }:

--- a/examples/simple-71/flake.nix
+++ b/examples/simple-71/flake.nix
@@ -1,24 +1,27 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     fdb-overlay.url = "path:./../..";
   };
 
-  outputs = { nixpkgs, flake-utils, fdb-overlay, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
-      system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ fdb-overlay.overlays.default ];
-        };
-      in
-      {
-        devShells.default = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [ libfdb71 ];
-          FDB_LIB_PATH = "${pkgs.libfdb71}/include";
-        };
-      }
-    );
+  outputs =
+    {
+      nixpkgs,
+      fdb-overlay,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ fdb-overlay.overlays.default ];
+      };
+    in
+    {
+      devShells."${system}".default = pkgs.mkShell {
+        nativeBuildInputs = with pkgs; [ libfdb71 ];
+        FDB_LIB_PATH = "${pkgs.libfdb71}/include";
+      };
+    };
 }

--- a/examples/simple-72/flake.nix
+++ b/examples/simple-72/flake.nix
@@ -1,8 +1,8 @@
 {
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixos-unstable;
-    flake-utils.url = github:numtide/flake-utils;
-    fdb-overlay.url = path:./../..;
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fdb-overlay.url = "path:./../..";
   };
 
   outputs = { nixpkgs, flake-utils, fdb-overlay, ... }:

--- a/examples/simple-72/flake.nix
+++ b/examples/simple-72/flake.nix
@@ -1,24 +1,27 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     fdb-overlay.url = "path:./../..";
   };
 
-  outputs = { nixpkgs, flake-utils, fdb-overlay, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
-      system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ fdb-overlay.overlays.default ];
-        };
-      in
-      {
-        devShells.default = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [ libfdb72 ];
-          FDB_LIB_PATH = "${pkgs.libfdb72}/include";
-        };
-      }
-    );
+  outputs =
+    {
+      nixpkgs,
+      fdb-overlay,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ fdb-overlay.overlays.default ];
+      };
+    in
+    {
+      devShells."${system}".default = pkgs.mkShell {
+        nativeBuildInputs = with pkgs; [ libfdb72 ];
+        FDB_LIB_PATH = "${pkgs.libfdb72}/include";
+      };
+    };
 }

--- a/examples/simple-73/flake.nix
+++ b/examples/simple-73/flake.nix
@@ -1,8 +1,8 @@
 {
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixos-unstable;
-    flake-utils.url = github:numtide/flake-utils;
-    fdb-overlay.url = path:./../..;
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fdb-overlay.url = "path:./../..";
   };
 
   outputs = { nixpkgs, flake-utils, fdb-overlay, ... }:

--- a/examples/simple-73/flake.nix
+++ b/examples/simple-73/flake.nix
@@ -1,24 +1,27 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     fdb-overlay.url = "path:./../..";
   };
 
-  outputs = { nixpkgs, flake-utils, fdb-overlay, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
-      system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ fdb-overlay.overlays.default ];
-        };
-      in
-      {
-        devShells.default = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [ libfdb73 ];
-          FDB_LIB_PATH = "${pkgs.libfdb73}/include";
-        };
-      }
-    );
+  outputs =
+    {
+      nixpkgs,
+      fdb-overlay,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ fdb-overlay.overlays.default ];
+      };
+    in
+    {
+      devShells."${system}".default = pkgs.mkShell {
+        nativeBuildInputs = with pkgs; [ libfdb73 ];
+        FDB_LIB_PATH = "${pkgs.libfdb73}/include";
+      };
+    };
 }

--- a/examples/simple/flake.nix
+++ b/examples/simple/flake.nix
@@ -1,8 +1,8 @@
 {
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixos-unstable;
-    flake-utils.url = github:numtide/flake-utils;
-    fdb-overlay.url = path:./../..;
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fdb-overlay.url = "path:./../..";
   };
 
   outputs = { nixpkgs, flake-utils, fdb-overlay, ... }:

--- a/examples/simple/flake.nix
+++ b/examples/simple/flake.nix
@@ -1,24 +1,27 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     fdb-overlay.url = "path:./../..";
   };
 
-  outputs = { nixpkgs, flake-utils, fdb-overlay, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
-      system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ fdb-overlay.overlays.default ];
-        };
-      in
-      {
-        devShells.default = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [ libfdb ];
-          FDB_LIB_PATH = "${pkgs.libfdb}/include";
-        };
-      }
-    );
+  outputs =
+    {
+      nixpkgs,
+      fdb-overlay,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ fdb-overlay.overlays.default ];
+      };
+    in
+    {
+      devShells."${system}".default = pkgs.mkShell {
+        nativeBuildInputs = with pkgs; [ libfdb ];
+        FDB_LIB_PATH = "${pkgs.libfdb}/include";
+      };
+    };
 }


### PR DESCRIPTION
Avoid using `flake-utils` in examples because it introduces extra indirection and hides standard flake features.

