### PR TITLE
chore: bump fdb 7.4.5 -> 7.4.6 + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
-        "path": "/nix/store/isfbldda5j8j6x3nbv1zim0c0dpf90v8-source",
-        "type": "path"
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",

--- a/pkgs/fdbcli/fdbcli_74.nix
+++ b/pkgs/fdbcli/fdbcli_74.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fdbcli";
-  version = "7.4.5";
+  version = "7.4.6";
 
   src = fetchurl {
     url = "https://github.com/apple/foundationdb/releases/download/${finalAttrs.version}/fdbcli.x86_64";
-    sha256 = "bd267011f2795f0f00ab635f301bca3a3be86a61bbf4299ebef139a03e8da601";
+    sha256 = "b0e47b9bd03addc745ba7ee283fa7a0c5fd7bfe2fa9d99bfb63692369d5659c6";
   };
 
   nativeBuildInputs = [ autoPatchelfHook xz zlib ];

--- a/pkgs/fdbserver/fdbserver_74.nix
+++ b/pkgs/fdbserver/fdbserver_74.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fdbserver";
-  version = "7.4.5";
+  version = "7.4.6";
 
   src = fetchurl {
     url = "https://github.com/apple/foundationdb/releases/download/${finalAttrs.version}/fdbserver.x86_64";
-    sha256 = "cccc7f5cfc13e3912bc55c10831091cacb7ea726c2abc2b883e6fe31668afa84";
+    sha256 = "2e9bd4ce461821c5d978e1119d4065e7f2db8da77655273a2ddd31177543aa18";
   };
 
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper xz zlib ]; 
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper xz zlib ];
 
   # fdbserver is a binary, not an archive
   unpackPhase = ":";

--- a/pkgs/libfdb/libfdb_74.nix
+++ b/pkgs/libfdb/libfdb_74.nix
@@ -2,8 +2,8 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libfdb_c";
-  version = "7.4.5";
-  sha256 = "f3eb95d649fc9a2193cfa22d6871ad01c03b23c341f2b6e8e4668a0f5609a1f4";
+  version = "7.4.6";
+  sha256 = "d1a097c3947fbc4aadfbfcb42daac101b4150160656377fba19bcdbe4656513c";
 
   src = fetchurl {
     url = "https://github.com/apple/foundationdb/releases/download/${finalAttrs.version}/libfdb_c.x86_64.so";

--- a/tests/cluster.nix
+++ b/tests/cluster.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 
-pkgs.nixosTest {
+pkgs.testers.nixosTest {
   name = "fdb-cluster-test";
   nodes = let
     common = {

--- a/tests/standalone.nix
+++ b/tests/standalone.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 
-pkgs.nixosTest {
+pkgs.testers.nixosTest {
   name = "simple-fdbserver-test";
   nodes.machine = { ... }:
     {


### PR DESCRIPTION
## Summary
- Bump FDB 7.4.5 → 7.4.6 (libfdb, fdbserver, fdbcli)
- Refresh `flake.lock` (nixpkgs)
- Add `.github/dependabot.yml` for nix flake inputs + github-actions

## Test plan
- [x] `nix flake check` passes (14 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)